### PR TITLE
Display 'EyeOff' glyph when element is hidden for better visibility

### DIFF
--- a/modules/ui/spawnedUI.lua
+++ b/modules/ui/spawnedUI.lua
@@ -776,7 +776,7 @@ function spawnedUI.drawSideButtons(element)
     style.pushStyleColor(not visible, ImGuiCol.Text, style.mutedColor)
 
     ImGui.SetNextItemAllowOverlap()
-    if ImGui.Button(IconGlyphs.EyeOutline) then
+    if ImGui.Button(visible and IconGlyphs.EyeOutline or IconGlyphs.EyeOff) then
         if spawnedUI.multiSelectActive() then
             element:setVisibleRecursive(not element.visible)
         else


### PR DESCRIPTION
Shows a hidden eye symbol when element is hidden to make it easier to identify when scrolling through larger lists.

![image](https://github.com/user-attachments/assets/af8d5816-a59c-4116-ab99-865ef5f63081)
