### PR TITLE
added basic proxy mesh support

### DIFF
--- a/modules/classes/spawn/mesh/proxyMesh.lua
+++ b/modules/classes/spawn/mesh/proxyMesh.lua
@@ -1,0 +1,56 @@
+local mesh = require("modules/classes/spawn/mesh/mesh")
+local style = require("modules/ui/style")
+local utils = require("modules/utils/utils")
+
+---Class for worldGenericProxyMeshNode
+---@class proxyMesh : mesh
+---@field public nearAutoHideDistance number
+local proxyMesh = setmetatable({}, { __index = mesh })
+
+function proxyMesh:new()
+	local o = mesh.new(self)
+
+    o.spawnListType = "list"
+    o.dataType = "Proxy Mesh"
+    o.modulePath = "mesh/proxyMesh"
+    o.node = "worldGenericProxyMeshNode"
+    o.description = "Places a proxy mesh, from a given .mesh file. Preview does not hide the mesh when close."
+    o.icon = IconGlyphs.BoxShadow
+
+    o.nearAutoHideDistance = 15
+
+    o.hideGenerate = true
+
+    setmetatable(o, { __index = self })
+   	return o
+end
+
+function proxyMesh:draw()
+    if not self.maxPropertyWidth then
+        self.maxPropertyWidth = utils.getTextMaxWidth({ "Appearance", "Collider", "Occluder", "Enable Wind Impulse", "Near Auto Hide Distance" }) + 2 * ImGui.GetStyle().ItemSpacing.x + ImGui.GetCursorPosX()
+    end
+    mesh.draw(self)
+
+    style.mutedText("Near Auto Hide Distance")
+    ImGui.SameLine()
+    ImGui.SetCursorPosX(self.maxPropertyWidth)
+    self.nearAutoHideDistance = style.trackedDragFloat(self.object, "##nearAutoHideDistance", self.nearAutoHideDistance, 0.5, 0.01, 9999, "%.2f", 95)
+end
+
+function proxyMesh:save()
+    local data = mesh.save(self)
+    data.nearAutoHideDistance = self.nearAutoHideDistance
+
+    return data
+end
+
+function proxyMesh:export()
+    local data = mesh.export(self)
+    data.type = "worldGenericProxyMeshNode"
+    data.data.nearAutoHideDistance = self.nearAutoHideDistance
+    data.data.nbNodesUnderProxy = 0
+
+    return data
+end
+
+return proxyMesh

--- a/modules/ui/spawnUI.lua
+++ b/modules/ui/spawnUI.lua
@@ -31,7 +31,8 @@ local types = {
             ["Mesh"] = { class = require("modules/classes/spawn/mesh/mesh"), index = 1 },
             ["Rotating Mesh"] = { class = require("modules/classes/spawn/mesh/rotatingMesh"), index = 2 },
             ["Cloth Mesh"] = { class = require("modules/classes/spawn/mesh/clothMesh"), index = 3 },
-            ["Dynamic Mesh"] = { class = require("modules/classes/spawn/physics/dynamicMesh"), index = 4 }
+            ["Dynamic Mesh"] = { class = require("modules/classes/spawn/physics/dynamicMesh"), index = 4 },
+            ["Proxy Mesh"] = { class = require("modules/classes/spawn/mesh/proxyMesh"), index = 4 }
         },
         index = 2
     },


### PR DESCRIPTION
Implements a minimum viable version of a proxy mesh via the `worldGenericProxyMeshNode` and exposing only the `nearAutoHideDistance` with `nbNodesUnderProxy` being set to 0 (no effect). 

While not having a ref to the underlying nodes can cause pop in, it is still better than not having proxy nodes available at all and can be implemented at a later stage.  

closes #22 