### PR TITLE
increase max characters in spawn new search / path input

### DIFF
--- a/modules/ui/spawnUI.lua
+++ b/modules/ui/spawnUI.lua
@@ -416,7 +416,7 @@ end
 
 function spawnUI.drawAll()
     ImGui.SetNextItemWidth(300 * style.viewSize)
-    spawnUI.filter, changed = ImGui.InputTextWithHint('##Filter', 'Search by name... (Supports pattern matching)', spawnUI.filter, 100)
+    spawnUI.filter, changed = ImGui.InputTextWithHint('##Filter', 'Search by name... (Supports pattern matching)', spawnUI.filter, 500)
     if changed then
         spawnUI.updateFilter()
     end


### PR DESCRIPTION
increase max characters in spawn new search / path input (was 100, now 500). max in game seems to be 199 (not accounting for embedded files) meaning 500 covers it with good margin and is consistent with what trackedtextinput uses.

closes #33 