### PR TITLE
Spawned tab tooltips & Export tab QoL

### DIFF
--- a/modules/classes/editor/element.lua
+++ b/modules/classes/editor/element.lua
@@ -428,7 +428,11 @@ function element:serialize()
 	return data
 end
 
-function element:save()
+---@param showToast boolean?
+function element:save(showToast)
+	showToast = showToast ~= false
+	local updatedInExport = 0
+
 	local data = self:serialize()
 
 	if self.fileName ~= self.name then
@@ -437,6 +441,28 @@ function element:save()
 
 	config.saveFile("data/objects/" .. self.fileName .. ".json", data)
 	self.sUI.spawner.baseUI.savedUI.reload()
+
+	if utils.isA(self, "positionableGroup") and self.supportsSaving and self.parent ~= nil and self.parent:isRoot(true) then
+		local baseUI = self.sUI and self.sUI.spawner and self.sUI.spawner.baseUI
+		if baseUI and baseUI.exportUI and baseUI.exportUI.syncGroup then
+			updatedInExport = baseUI.exportUI.syncGroup(self.name) or 0
+		end
+
+		if showToast then
+			local msg = string.format("Saved group \"%s\"", self.name)
+			if updatedInExport > 0 then
+				if updatedInExport == 1 then
+					msg = msg .. " and updated it in export list"
+				else
+					msg = msg .. string.format(" and updated %s entries in export list", updatedInExport)
+				end
+			end
+
+			ImGui.ShowToast(ImGui.Toast.new(ImGui.ToastType.Success, 2500, msg))
+		end
+	end
+
+	return updatedInExport
 end
 
 return element

--- a/modules/ui/exportUI.lua
+++ b/modules/ui/exportUI.lua
@@ -324,7 +324,25 @@ function exportUI.drawTemplates()
 
         ImGui.BeginChildFrame(2, 0, settings.exportTemplatesHeight)
 
+        local sortedTemplates = {}
         for key, data in pairs(exportUI.templates) do
+            table.insert(sortedTemplates, { key = key, data = data })
+        end
+
+        table.sort(sortedTemplates, function(a, b)
+            local aName = tostring(a.data.projectName or a.key or ""):lower()
+            local bName = tostring(b.data.projectName or b.key or ""):lower()
+
+            if aName == bName then
+                return tostring(a.key) < tostring(b.key)
+            end
+
+            return aName < bName
+        end)
+
+        for _, entry in ipairs(sortedTemplates) do
+            local key = entry.key
+            local data = entry.data
             ImGui.BeginGroup()
 
             local nodeFlags = ImGuiTreeNodeFlags.SpanFullWidth
@@ -645,6 +663,14 @@ function exportUI.draw()
     ImGui.SetNextItemWidth(200 * style.viewSize)
     ImGui.SetCursorPosX(exportUI.mainPropertiesWidth)
     exportUI.projectName = ImGui.InputTextWithHint('##name', 'Export name...', exportUI.projectName, 100)
+    if exportUI.projectName ~= "" then
+        ImGui.SameLine()
+        style.pushButtonNoBG(true)
+        if ImGui.Button(IconGlyphs.Close .. "##clearExportProjectName") then
+            exportUI.projectName = ""
+        end
+        style.pushButtonNoBG(false)
+    end
 
     ImGui.Text("XL Format")
     ImGui.SameLine()

--- a/modules/ui/savedUI.lua
+++ b/modules/ui/savedUI.lua
@@ -17,6 +17,36 @@ savedUI = {
     maxTextWidth = nil
 }
 
+local function isSavedGroup(data)
+    return data and (data.type == "group" or data.modulePath == "modules/classes/editor/positionableGroup")
+end
+
+local function removeFromExportListIfPresent(data)
+    if not isSavedGroup(data) then
+        return 0
+    end
+
+    local baseUI = savedUI.spawner and savedUI.spawner.baseUI
+    if not baseUI or not baseUI.exportUI or not baseUI.exportUI.removeGroupByName then
+        return 0
+    end
+
+    return baseUI.exportUI.removeGroupByName(data.name)
+end
+
+local function showDeletedGroupToast(data, removedFromExport)
+    if not isSavedGroup(data) then
+        return
+    end
+
+    local msg = string.format("Deleted saved group \"%s\"", data.name)
+    if removedFromExport > 0 then
+        msg = msg .. " and removed it from export list"
+    end
+
+    ImGui.ShowToast(ImGui.Toast.new(ImGui.ToastType.Success, 2500, msg))
+end
+
 function savedUI.convertObject(object, getState)
     local spawnable = require("modules/classes/spawn/entity/entityTemplate"):new()
     spawnable:loadSpawnData({
@@ -262,6 +292,9 @@ function savedUI.deleteData(data)
     else
         os.remove("data/objects/" .. data.name .. ".json")
         savedUI.files[data.name .. ".json"] = nil
+
+        local removedFromExport = removeFromExportListIfPresent(data)
+        showDeletedGroupToast(data, removedFromExport)
     end
 end
 
@@ -286,6 +319,11 @@ function savedUI.handlePopUp()
                 ImGui.CloseCurrentPopup()
                 os.remove("data/objects/" .. savedUI.deleteFile.name .. ".json")
                 savedUI.files[savedUI.deleteFile.name .. ".json"] = nil
+
+                local removedFromExport = removeFromExportListIfPresent(savedUI.deleteFile)
+                showDeletedGroupToast(savedUI.deleteFile, removedFromExport)
+
+                savedUI.deleteFile = nil
                 savedUI.popup = false
             end
             ImGui.EndPopup()

--- a/modules/ui/spawnedUI.lua
+++ b/modules/ui/spawnedUI.lua
@@ -1147,16 +1147,19 @@ function spawnedUI.drawTop()
             end
         end
     end
+    style.tooltip("Save all root groups")
     ImGui.SameLine()
     if ImGui.Button(IconGlyphs.CollapseAllOutline) then
         for _, child in pairs(spawnedUI.root.childs) do
             child:setHeaderStateRecursive(false)
         end
     end
+    style.tooltip("Fold all groups")
     ImGui.SameLine()
     if ImGui.Button(IconGlyphs.ExpandAllOutline) then
         spawnedUI.root:setHeaderStateRecursive(true)
     end
+    style.tooltip("Expand all groups")
     ImGui.SameLine()
     if ImGui.Button(IconGlyphs.EyeMinusOutline) then
         if spawnedUI.filter ~= "" then
@@ -1167,6 +1170,7 @@ function spawnedUI.drawTop()
             spawnedUI.root:setVisibleRecursive(false)
         end
     end
+    style.tooltip("Hide all elements (or filtered elements)")
     ImGui.SameLine()
     if ImGui.Button(IconGlyphs.EyePlusOutline) then
         if spawnedUI.filter ~= "" then
@@ -1177,6 +1181,7 @@ function spawnedUI.drawTop()
             spawnedUI.root:setVisibleRecursive(true)
         end
     end
+    style.tooltip("Show all elements (or filtered elements)")
     ImGui.SameLine()
     if ImGui.Button(IconGlyphs.Undo) then
         history.undo()

--- a/modules/ui/spawnedUI.lua
+++ b/modules/ui/spawnedUI.lua
@@ -216,6 +216,25 @@ local function hotkeyRunConditionGlobal()
     return input.context.hierarchy.hovered or input.context.viewport.hovered
 end
 
+function spawnedUI.saveAllRootGroups()
+    local saved = 0
+    local updatedInExport = 0
+
+    for _, entry in pairs(spawnedUI.paths) do
+        if utils.isA(entry.ref, "positionableGroup") and entry.ref.supportsSaving and entry.ref.parent ~= nil and entry.ref.parent:isRoot(true) then
+            updatedInExport = updatedInExport + (entry.ref:save(false) or 0)
+            saved = saved + 1
+        end
+    end
+
+    local msg = string.format("Saved %s root group%s", saved, saved == 1 and "" or "s")
+    if updatedInExport > 0 then
+        msg = msg .. string.format(" and updated %s export list entr%s", updatedInExport, updatedInExport == 1 and "y" or "ies")
+    end
+
+    ImGui.ShowToast(ImGui.Toast.new(ImGui.ToastType.Success, 2500, msg))
+end
+
 function spawnedUI.registerHotkeys()
     input.registerImGuiHotkey({ ImGuiKey.Z, ImGuiKey.LeftCtrl }, function()
         history.undo()
@@ -231,11 +250,7 @@ function spawnedUI.registerHotkeys()
         end
     end, hotkeyRunConditionGlobal)
     input.registerImGuiHotkey({ ImGuiKey.S, ImGuiKey.LeftCtrl }, function()
-        for _, entry in pairs(spawnedUI.paths) do
-            if utils.isA(entry.ref, "positionableGroup") and entry.ref.supportsSaving and entry.ref.parent ~= nil and entry.ref.parent:isRoot(true) then
-                entry.ref:save()
-            end
-        end
+        spawnedUI.saveAllRootGroups()
     end)
     input.registerImGuiHotkey({ ImGuiKey.C, ImGuiKey.LeftCtrl }, function()
         if #spawnedUI.selectedPaths == 0 or spawnedUI.nameBeingEdited then return end
@@ -1141,11 +1156,7 @@ function spawnedUI.drawTop()
     style.tooltip("Toggle 3D-Editor mode")
     ImGui.SameLine()
     if ImGui.Button(IconGlyphs.ContentSaveAllOutline) then
-        for _, entry in pairs(spawnedUI.paths) do
-            if utils.isA(entry.ref, "positionableGroup") and entry.ref.supportsSaving and entry.ref.parent ~= nil and entry.ref.parent:isRoot(true) then
-                entry.ref:save()
-            end
-        end
+        spawnedUI.saveAllRootGroups()
     end
     style.tooltip("Save all root groups")
     ImGui.SameLine()

--- a/modules/utils/settings.lua
+++ b/modules/utils/settings.lua
@@ -42,6 +42,8 @@ local config = require("modules/utils/config")
 ---@field public cameraRotateSpeed number
 ---@field public cameraZoomSpeed number
 ---@field public setLoadedGroupAsSpawnNew boolean
+---@field public exportGroupsHeight number
+---@field public exportTemplatesHeight number
 local settingsData = {
     spawnPos = 1,
     spawnDist = 4,
@@ -82,6 +84,8 @@ local settingsData = {
     cameraRotateSpeed = 0.4,
     cameraZoomSpeed = 2.75,
     setLoadedGroupAsSpawnNew = false,
+    exportGroupsHeight = 260,
+    exportTemplatesHeight = 160,
 
     filterTags = {},
     favoritesFilter = "",


### PR DESCRIPTION
For the Spawned tab :
- Added 5 missing tooltips

For the Export tab :
- Added button to clear the group list
- Added button to refresh variants of the group list
- Made the Export templates and Groups sections resizable (with the double click feature to reset the size)
- Added a counter for the groups section
- Added a warning before export if some groups have the same name
- Added a popup warning if, during the refresh variants action, some groups got deleted. The popup ask if the user want to remove them from the list
- Added a button to clear the Project Name field
- Sort export templates alphabetically

[Demo video on Discord](https://discord.com/channels/717692382849663036/814064062815141909/1469846637991170120)