### PR TITLE
Partial group roll-pitch fix

### DIFF
--- a/modules/classes/editor/positionableGroup.lua
+++ b/modules/classes/editor/positionableGroup.lua
@@ -277,7 +277,7 @@ function positionableGroup:drawRotation(rotation)
 	self:handleRightAngleChange("yaw", shiftActive and not finished)
 	style.popGreyedOut(locked)
 	ImGui.SameLine()
-	style.mutedText(IconGlyphs.InformationOutline)
+	style.mutedText(IconGlyphs.AlertOutline)
 	style.tooltip("Experimental Roll/Pitch\nUnreliable between -3.60° and 3.60°\nUse with caution")
 end
 


### PR DESCRIPTION
**Current status :** 
Roll/Pitch almost fixed
Still buggy between -3.60° and 3.60°, monstly encountered on groups made using VS.
Other handmade groups seem to work consistently.

Main changes is that the roll/pith is no longer incremental but recalculated from the starting point of the mouse drag action, to avoid the accumulation of drift.


UI changes :
- Roll/Pitch input background color changed to orange when in the risky zone (though the "Set Current Rotation as Indentity" biases it)
- Added info icon with tooltip, next to the yaw input, to tell users to be carefull with the pitch/roll of groups.

