### PR TITLE
fix proxyMesh always failing to draw properties

### DIFF
--- a/modules/classes/spawn/mesh/proxyMesh.lua
+++ b/modules/classes/spawn/mesh/proxyMesh.lua
@@ -27,7 +27,7 @@ end
 
 function proxyMesh:draw()
     if not self.maxPropertyWidth then
-        self.maxPropertyWidth = math.max(self.maxPropertyWidth, utils.getTextMaxWidth({ "Near Auto Hide Distance" }) + 2 * ImGui.GetStyle().ItemSpacing.x + ImGui.GetCursorPosX())
+        self.maxPropertyWidth = math.max(utils.getTextMaxWidth({ "Near Auto Hide Distance" }) + 2 * ImGui.GetStyle().ItemSpacing.x + ImGui.GetCursorPosX())
     end
     mesh.draw(self)
 


### PR DESCRIPTION
math.max() only accepts numbers and throws when provided a nil value, as such passing it self.maxPropertyWidth when it was nil stopped the properties from drawing