### PR TITLE
feat: add mesh visibility distance controls

### DIFF
--- a/modules/classes/spawn/mesh/mesh.lua
+++ b/modules/classes/spawn/mesh/mesh.lua
@@ -39,6 +39,7 @@ local lossyConversionPairs = {
 ---@field protected occluderTypes table
 ---@field protected hasOccluder boolean|table
 ---@field protected windImpulseEnabled boolean
+---@field protected forceAutoHideDistance number
 ---@field protected castLocalShadows integer
 ---@field protected castRayTracedGlobalShadows integer
 ---@field protected castRayTracedLocalShadows integer
@@ -73,6 +74,7 @@ function mesh:new()
     o.occluderTypes = utils.enumTable("visWorldOccluderType")
     o.hasOccluder = false
     o.windImpulseEnabled = true
+    o.forceAutoHideDistance = 0
 
     o.castLocalShadows = 0
     o.castRayTracedGlobalShadows = 0
@@ -263,6 +265,7 @@ function mesh:save()
     data.castShadows = self.castShadows
     data.occluderType = self.occluderType
     data.windImpulseEnabled = self.windImpulseEnabled
+    data.forceAutoHideDistance = self.forceAutoHideDistance
 
     return data
 end
@@ -363,7 +366,7 @@ function mesh:draw()
     spawnable.draw(self)
 
     if not self.maxPropertyWidth then
-        self.maxPropertyWidth = utils.getTextMaxWidth({ "Appearance", "Collider", "Occluder", "Enable Wind Impulse" }) + 2 * ImGui.GetStyle().ItemSpacing.x + ImGui.GetCursorPosX()
+        self.maxPropertyWidth = utils.getTextMaxWidth({ "Appearance", "Collider", "Occluder", "Enable Wind Impulse", "Force Auto-Hide Distance" }) + 2 * ImGui.GetStyle().ItemSpacing.x + ImGui.GetCursorPosX()
     end
 
     style.pushGreyedOut(#self.apps == 0)
@@ -420,6 +423,12 @@ function mesh:draw()
     ImGui.SetCursorPosX(self.maxPropertyWidth)
     self.windImpulseEnabled, _ = style.trackedCheckbox(self.object, "##windImpulseEnabled", self.windImpulseEnabled)
     style.tooltip("Enable wind impulse for this mesh, not previewed.")
+
+    style.mutedText("Force Auto-Hide Distance")
+    ImGui.SameLine()
+    ImGui.SetCursorPosX(self.maxPropertyWidth)
+    self.forceAutoHideDistance = style.trackedDragFloat(self.object, "##forceAutoHideDistance", self.forceAutoHideDistance, 1, 0, 99999, "%.1f", 110)
+    style.tooltip("Overrides the mesh node's auto-hide distance. 0 keeps the engine default; very large values can increase rendering cost.")
 
     self.shadowHeaderState = ImGui.TreeNodeEx("Shadow Settings")
 
@@ -605,6 +614,43 @@ end
 
 function mesh:getGroupedProperties()
     local properties = spawnable.getGroupedProperties(self)
+
+    properties["meshVisibility"] = {
+        name = "Mesh Visibility",
+        id = "meshVisibility",
+        data = {
+            forceAutoHideDistance = 0,
+            maxPropertyWidth = nil
+        },
+        draw = function(element, entries)
+            local visibilityData = element.groupOperationData["meshVisibility"]
+            if not visibilityData.maxPropertyWidth then
+                visibilityData.maxPropertyWidth = utils.getTextMaxWidth({ "Force Auto-Hide Distance" }) + ImGui.GetStyle().ItemSpacing.x * 2 + ImGui.GetCursorPosX()
+            end
+
+            style.mutedText("Force Auto-Hide Distance")
+            ImGui.SameLine()
+            ImGui.SetCursorPosX(visibilityData.maxPropertyWidth)
+            ImGui.SetNextItemWidth(110 * style.viewSize)
+            visibilityData.forceAutoHideDistance, _ = ImGui.DragFloat("##groupForceAutoHideDistance", visibilityData.forceAutoHideDistance, 1, 0, 99999, "%.1f")
+            style.tooltip("0 keeps the engine default; very large values can increase rendering cost.")
+            ImGui.SameLine()
+            if ImGui.Button("Apply##groupForceAutoHideDistance") then
+                history.addAction(history.getMultiSelectChange(entries))
+
+                local nApplied = 0
+                for _, entry in ipairs(entries) do
+                    if entry.spawnable and entry.spawnable.forceAutoHideDistance ~= nil then
+                        entry.spawnable.forceAutoHideDistance = visibilityData.forceAutoHideDistance
+                        nApplied = nApplied + 1
+                    end
+                end
+
+                ImGui.ShowToast(ImGui.Toast.new(ImGui.ToastType.Success, 2500, string.format("Set force auto-hide distance for %s mesh nodes", nApplied)))
+            end
+        end,
+        entries = { self.object }
+    }
 
     properties["meshConverter"] = {
         name = "Mesh Conversion",
@@ -919,6 +965,7 @@ function mesh:export()
         castRayTracedGlobalShadows = self.shadowCastingModeEnum[self.castRayTracedGlobalShadows + 1],
         castRayTracedLocalShadows = self.shadowCastingModeEnum[self.castRayTracedLocalShadows + 1],
         castShadows = self.shadowCastingModeEnum[self.castShadows + 1],
+        forceAutoHideDistance = self.forceAutoHideDistance,
         occluderType = self.occluderTypes[self.occluderType + 1],
         windImpulseEnabled = self.windImpulseEnabled and 1 or 0
     }

--- a/modules/classes/spawn/physics/dynamicMesh.lua
+++ b/modules/classes/spawn/physics/dynamicMesh.lua
@@ -7,7 +7,6 @@ local utils = require("modules/utils/utils")
 ---Class for worldDynamicMeshNode
 ---@class dynamicMesh : mesh
 ---@field private startAsleep boolean
----@field private forceAutoHideDistance number
 local dynamicMesh = setmetatable({}, { __index = mesh })
 
 function dynamicMesh:new()
@@ -65,7 +64,6 @@ end
 function dynamicMesh:save()
     local data = mesh.save(self)
     data.startAsleep = self.startAsleep
-    data.forceAutoHideDistance = self.forceAutoHideDistance or 150
 
     return data
 end
@@ -76,7 +74,7 @@ function dynamicMesh:draw()
     mesh.draw(self)
 
     if calculateMaxWidth then
-        self.maxPropertyWidth = math.max(self.maxPropertyWidth, utils.getTextMaxWidth({ "Start Asleep", "Auto Hide Distance" }) + 2 * ImGui.GetStyle().ItemSpacing.x + ImGui.GetCursorPosX())
+        self.maxPropertyWidth = math.max(self.maxPropertyWidth, utils.getTextMaxWidth({ "Start Asleep" }) + 2 * ImGui.GetStyle().ItemSpacing.x + ImGui.GetCursorPosX())
     end
 
     style.mutedText("Start Asleep")
@@ -84,11 +82,6 @@ function dynamicMesh:draw()
     ImGui.SetCursorPosX(self.maxPropertyWidth)
     self.startAsleep = style.trackedCheckbox(self.object, "##startAsleep", self.startAsleep)
 
-    style.mutedText("Auto Hide Distance")
-    ImGui.SameLine()
-    ImGui.SetCursorPosX(self.maxPropertyWidth)
-    self.forceAutoHideDistance = style.trackedDragFloat(self.object, "##forceAutoHideDistance", self.forceAutoHideDistance, 0.1, 0, 1000, "%.1f")
-    
     self:drawConversionSelector("##dynamicMeshConverterType", "Lossy Conversion##dynamicMeshSingle")
 end
 
@@ -96,7 +89,6 @@ function dynamicMesh:export()
     local data = mesh.export(self)
     data.type = "worldDynamicMeshNode"
     data.data.startAsleep = self.startAsleep and 1 or 0
-    data.data.forceAutoHideDistance = self.forceAutoHideDistance
 
     return data
 end

--- a/modules/classes/spawn/spawnable.lua
+++ b/modules/classes/spawn/spawnable.lua
@@ -78,8 +78,10 @@ function spawnable:new()
     o.worldNodePropertyWidth = nil
 
     o.noExport = false
-    o.primaryRange = 120
-    o.secondaryRange = 100
+    -- These names are part of the saved-build format. During export primaryRange
+    -- maps to UkFloat1, while secondaryRange maps to MaxStreamingDistance.
+    o.primaryRange = 100
+    o.secondaryRange = 120
     o.uk10 = 1024
     o.uk11 = 512
     o.streamingMultiplier = 1
@@ -304,6 +306,7 @@ function spawnable:getProperties()
             ImGui.SameLine()
             ImGui.SetCursorPosX(self.worldNodePropertyWidth)
             self.primaryRange, _, _ = style.trackedDragFloat(self.object, "##primaryRange", self.primaryRange, 0.1, 0, 9999, "%.2f", 90)
+            style.tooltip("Exports to worldNodeData.UkFloat1")
             ImGui.SameLine()
             local distance = self.streamingRefPointOverride and utils.distanceVector(self.streamingRefPoint, GetPlayer():GetWorldPosition()) or utils.distanceVector(self.position, GetPlayer():GetWorldPosition())
             style.styledText(IconGlyphs.AxisArrowInfo, distance > self.primaryRange and 0xFF0000FF or 0xFF00FF00)
@@ -313,6 +316,7 @@ function spawnable:getProperties()
             ImGui.SameLine()
             ImGui.SetCursorPosX(self.worldNodePropertyWidth)
             self.secondaryRange, _, _ = style.trackedDragFloat(self.object, "##secondaryRange", self.secondaryRange, 0.1, 0, 9999, "%.2f", 90)
+            style.tooltip("Exports to worldNodeData.MaxStreamingDistance")
             ImGui.SameLine()
             style.styledText(IconGlyphs.AxisArrowInfo, distance > self.secondaryRange and 0xFF0000FF or 0xFF00FF00)
             style.tooltip(string.format("Distance to from %s: %.2f", self.streamingRefPointOverride and "reference point" or "node position", distance))
@@ -370,25 +374,51 @@ function spawnable:getGroupedProperties()
         id = "worldNode",
 		data = {
             multiplier = 1,
+            primaryRange = 100,
+            secondaryRange = 120,
             maxPropertyWidth = nil
         },
 		draw = function(element, entries)
             if not element.groupOperationData["streamingProperties"].maxPropertyWidth then
-                element.groupOperationData["streamingProperties"].maxPropertyWidth = utils.getTextMaxWidth({ "Streaming Distances", "NodeRef's", "Override Streaming Ref. Point", "Streaming Ref. Point" }) + ImGui.GetStyle().ItemSpacing.x * 2 + ImGui.GetCursorPosX()
+                element.groupOperationData["streamingProperties"].maxPropertyWidth = utils.getTextMaxWidth({ "Set Streaming Distances", "Streaming Distances Multiplier", "NodeRef's", "Override Streaming Ref. Point", "Streaming Ref. Point" }) + ImGui.GetStyle().ItemSpacing.x * 2 + ImGui.GetCursorPosX()
+            end
+
+            local streamingData = element.groupOperationData["streamingProperties"]
+
+            style.mutedText("Set Streaming Distances")
+            ImGui.SameLine()
+            ImGui.SetCursorPosX(streamingData.maxPropertyWidth)
+            ImGui.SetNextItemWidth(90 * style.viewSize)
+            streamingData.primaryRange, _ = ImGui.DragFloat("##groupPrimaryRange", streamingData.primaryRange, 0.1, 0, 9999, "P %.2f")
+            style.tooltip("Primary Range; exports to worldNodeData.UkFloat1")
+            ImGui.SameLine()
+            ImGui.SetNextItemWidth(90 * style.viewSize)
+            streamingData.secondaryRange, _ = ImGui.DragFloat("##groupSecondaryRange", streamingData.secondaryRange, 0.1, 0, 9999, "S %.2f")
+            style.tooltip("Secondary Range; exports to worldNodeData.MaxStreamingDistance")
+            ImGui.SameLine()
+            if ImGui.Button("Apply##groupStreamingDistances") then
+                history.addAction(history.getMultiSelectChange(entries))
+
+                for _, entry in ipairs(entries) do
+                    entry.spawnable.primaryRange = streamingData.primaryRange
+                    entry.spawnable.secondaryRange = streamingData.secondaryRange
+                end
+
+                ImGui.ShowToast(ImGui.Toast.new(ImGui.ToastType.Success, 2500, string.format("Set streaming distances for %s nodes", #entries)))
             end
 
             style.mutedText("Streaming Distances Multiplier")
             ImGui.SetNextItemWidth(80 * style.viewSize)
             ImGui.SameLine()
-            ImGui.SetCursorPosX(element.groupOperationData["streamingProperties"].maxPropertyWidth)
-            element.groupOperationData["streamingProperties"].multiplier, _ = ImGui.DragFloat("##groupStreamingDistancesMultiplier", element.groupOperationData["streamingProperties"].multiplier, 0.01, 0, 50, "x%.2f")
+            ImGui.SetCursorPosX(streamingData.maxPropertyWidth)
+            streamingData.multiplier, _ = ImGui.DragFloat("##groupStreamingDistancesMultiplier", streamingData.multiplier, 0.01, 0, 50, "x%.2f")
             style.tooltip("Multiplier for streaming values, when using \"Auto-Set\"")
             ImGui.SameLine()
             if ImGui.Button("Auto-Set") then
                 history.addAction(history.getMultiSelectChange(entries))
 
                 for _, entry in ipairs(entries) do
-                    local values = entry.spawnable:calculateStreamingValues(element.groupOperationData["streamingProperties"].multiplier * entry.spawnable.streamingMultiplier)
+                    local values = entry.spawnable:calculateStreamingValues(streamingData.multiplier * entry.spawnable.streamingMultiplier)
 
                     entry.spawnable.primaryRange = values.primary
                     entry.spawnable.secondaryRange = values.secondary
@@ -582,9 +612,9 @@ function spawnable:calculateStreamingValues(multiplier)
     -- multiplier = math.min(1, math.max(0, falloffRange * math.log(math.max(0, maxAxis + minSize))))
     local scale = self:getSize()
 
-    local primary = math.max(math.max(scale.x, scale.y, scale.z) * multiplier * 60, 25)
-    primary = math.min(primary, 200 * multiplier)
-    local secondary = primary * 0.8
+    local secondary = math.max(math.max(scale.x, scale.y, scale.z) * multiplier * 60, 25)
+    secondary = math.min(secondary, 200 * multiplier)
+    local primary = secondary * 0.8
 
     return { primary = primary, secondary = secondary, uk10 = self.uk10, uk11 = self.uk11 }
 end


### PR DESCRIPTION
This adds controls for mesh streaming and auto-hide distances. I ran into the _issue_, if I can say so, while helping a mod author troubleshoot a small World Builder project for the Glen apartment: most of the structural meshes disappeared at around 120 metres, and the workaround was to edit the compiled `.streamingsector` manually after export. Exposing the same values in World Builder avoids that extra step and may be useful for other distant structures as well.

Changes:

- Added `Force Auto-Hide Distance` to individual mesh properties and multi-selection.
- Added exact Primary and Secondary Range inputs to the grouped World Node properties.
- Corrected the default and Auto-Set ordering to match the existing export mapping: Primary maps to `UkFloat1`, while Secondary maps to `MaxStreamingDistance`.
- Moved the existing Dynamic Mesh auto-hide handling into the shared mesh class, while keeping its current default of `150`.

Existing saved values continue to load unchanged. We tested the build together, and the new values exported correctly and fixed the distance issue in game. I tried to keep the naming and UI text consistent with the rest of the project, but feel free to adjust anything that doesn't fit.